### PR TITLE
fix: use node-easyocr's bundled venv python instead of requiring global pip install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1093,17 +1093,11 @@ ios_tap with x=187 y=420
 
 The tool uses EasyOCR (Python-based) for text recognition. It provides excellent accuracy on colored backgrounds and stylized text common in mobile UIs.
 
-### Installing EasyOCR (Required for OCR)
+### EasyOCR Setup
 
-```bash
-# Install Python 3.10+ if not already installed
-brew install python@3.11
+EasyOCR and its Python dependencies are installed automatically by the `node-easyocr` package. You just need Python 3.6+ available on your system (e.g. `brew install python@3.11`).
 
-# Install EasyOCR
-pip3 install easyocr
-```
-
-First run will download models (~100MB for English). Additional language models are downloaded automatically when configured.
+The first OCR call will download language models (~100MB for English). Additional language models are downloaded automatically when configured.
 
 ### OCR Language Configuration
 

--- a/src/core/ocr.ts
+++ b/src/core/ocr.ts
@@ -147,16 +147,18 @@ async function getEasyOCR(): Promise<import("node-easyocr").EasyOCR> {
             // own recognition model that may need downloading.
             const pythonPath = (ocr as any).pythonPath || "python3";
             const langArg = JSON.stringify(languages);
-            await new Promise<void>((resolve, reject) => {
+            await withTimeout(new Promise<void>((resolve, reject) => {
                 const proc = spawn(pythonPath, [
                     "-c", `import easyocr; easyocr.Reader(${langArg}, verbose=False)`
                 ]);
+                let stderr = "";
+                proc.stderr.on("data", (d: Buffer) => { stderr += d; });
                 proc.on("close", (code) => {
                     if (code === 0) resolve();
-                    else reject(new Error(`EasyOCR model setup exited with code ${code}. Ensure Python 3.6+ is installed.`));
+                    else reject(new Error(`EasyOCR model setup failed (code ${code}): ${stderr.trim() || "unknown error"}. Ensure Python 3.6+ is installed.`));
                 });
                 proc.on("error", reject);
-            });
+            }), 120000, "EasyOCR model download timeout -- check your network connection");
 
             await withTimeout(ocr.init(languages), 30000, "EasyOCR init timeout. Ensure Python 3.6+ is available on your system.");
             easyOCRInstance = ocr;


### PR DESCRIPTION
I really think this is a great MCP server, but don't want to install global Python packages using pip — so I was poking around and noticed that node-easyocr's preinstall script already creates an >800MB venv with easyocr/torch installed, containing easyocr, pytorch, cv2, etc hidden inside `~/.npm/_npx/` when this MCP is run with npx.

```
~$ du -sh .npm/_npx/a912162c7e77d339/node_modules/node-easyocr/venv/lib/python3.14/site-packages
866M	.npm/_npx/a912162c7e77d339/node_modules/node-easyocr/venv/lib/python3.14/site-packages
~$ du -sm .npm/_npx/a912162c7e77d339/node_modules/node-easyocr/venv/lib/python3.14/site-packages/* | sort -n  | tail -n10
13	.npm/_npx/a912162c7e77d339/node_modules/node-easyocr/venv/lib/python3.14/site-packages/pip
15	.npm/_npx/a912162c7e77d339/node_modules/node-easyocr/venv/lib/python3.14/site-packages/PIL
16	.npm/_npx/a912162c7e77d339/node_modules/node-easyocr/venv/lib/python3.14/site-packages/easyocr
18	.npm/_npx/a912162c7e77d339/node_modules/node-easyocr/venv/lib/python3.14/site-packages/networkx
29	.npm/_npx/a912162c7e77d339/node_modules/node-easyocr/venv/lib/python3.14/site-packages/skimage
33	.npm/_npx/a912162c7e77d339/node_modules/node-easyocr/venv/lib/python3.14/site-packages/numpy
76	.npm/_npx/a912162c7e77d339/node_modules/node-easyocr/venv/lib/python3.14/site-packages/sympy
98	.npm/_npx/a912162c7e77d339/node_modules/node-easyocr/venv/lib/python3.14/site-packages/scipy
119	.npm/_npx/a912162c7e77d339/node_modules/node-easyocr/venv/lib/python3.14/site-packages/cv2
402	.npm/_npx/a912162c7e77d339/node_modules/node-easyocr/venv/lib/python3.14/site-packages/torch
```

However node-easyocr's runtime hardcodes `pythonPath = 'python3'`, a bug that seems to ignore the venv entirely. This means OCR only works if easyocr is installed globally, and requires a second install of all these depdencies.

We can use the venv it makes (without a PR to fix node-easyocr) by looking up `dirname(require.resolve("node-easyocr"))` and setting the `EasyOCR` instance's `pythonPath` to the venv-specific Python... however... on first run, easyocr downloads models and prints a progress bar to stdout because `verbose=True` is being used by node-easyocr's Python wrapper, which breaks the JSON expectation.

This PR contains two fixes to work around this issue by (1) looking up the venv node-easyocr has already made, to save disk space, and (2) running easyocr inside the venv once before calling node-easyocr, so that if the models haven't been downloaded yet, they will be ready when the call to node-easyocr is made.

This is all to work around https://github.com/techbyvj/node-easyocr, and it would probably be better to contribute this upstream (I've just done so in https://github.com/techbyvj/node-easyocr/pull/3). An alternative is just to vendor node-easyocr's functionality and wrap Python's easyocr lib directly in this MCP and get rid of the dependency.. but that seemed like a bigger lift. Anyway, this change is working for me so I figured I would submit it back to you!

Thanks again for this super useful MCP!