### PR TITLE
fix: remove IIFE wrapping in executeExpressionCore that discards return values

### DIFF
--- a/src/core/executor.ts
+++ b/src/core/executor.ts
@@ -109,63 +109,6 @@ function validateAndPreprocessExpression(expression: string): ExpressionValidati
     };
 }
 
-/**
- * Detect if an expression contains multiple statements or declarations.
- * These cannot be wrapped with `return (expr)` — they need block wrapping.
- *
- * Examples:
- * - "console.log('x'); 'result'"  → multi-statement (semicolon between statements)
- * - "var x = 1; btoa(x)"          → declaration + multi-statement
- * - "var x = 1"                    → declaration
- * - "JSON.stringify(obj)"          → single expression (NOT multi-statement)
- * - "JSON.stringify({a: 'x;y'})"  → single expression with semicolon in string
- */
-function isMultiStatementExpression(expr: string): boolean {
-    const trimmed = expr.trim();
-
-    // Starts with a declaration or statement keyword
-    if (/^(var|let|const|function|class|for|while|if|switch|try|do|throw)\b/.test(trimmed)) {
-        return true;
-    }
-
-    // Check for semicolons that separate statements (not trailing, not inside strings)
-    // Remove the trailing semicolon and whitespace first
-    const withoutTrailing = trimmed.replace(/;\s*$/, '');
-
-    // Simple heuristic: check if there's a semicolon that's likely between statements
-    // Skip semicolons inside string literals by tracking quote state
-    let inSingle = false;
-    let inDouble = false;
-    let inTemplate = false;
-    let escaped = false;
-
-    for (let i = 0; i < withoutTrailing.length; i++) {
-        const ch = withoutTrailing[i];
-
-        if (escaped) {
-            escaped = false;
-            continue;
-        }
-
-        if (ch === '\\') {
-            escaped = true;
-            continue;
-        }
-
-        if (ch === "'" && !inDouble && !inTemplate) {
-            inSingle = !inSingle;
-        } else if (ch === '"' && !inSingle && !inTemplate) {
-            inDouble = !inDouble;
-        } else if (ch === '`' && !inSingle && !inDouble) {
-            inTemplate = !inTemplate;
-        } else if (ch === ';' && !inSingle && !inDouble && !inTemplate) {
-            // Found a semicolon outside of strings — multi-statement
-            return true;
-        }
-    }
-
-    return false;
-}
 
 // Error patterns that indicate a stale/destroyed context
 const CONTEXT_ERROR_PATTERNS = [
@@ -244,12 +187,10 @@ async function executeExpressionCore(
     const TIMEOUT_MS = timeoutMs;
     const currentMessageId = getNextMessageId();
 
-    // Wrap expression with global polyfill for Hermes compatibility
-    // Multi-statement expressions (var x = 1; foo(x)) can't use `return (expr)` wrapping
-    // because declarations and semicolons are invalid inside parenthesized expressions
-    const wrappedExpression = isMultiStatementExpression(cleanedExpression)
-        ? `(function() { ${GLOBAL_POLYFILL} ${cleanedExpression} })()`
-        : `(function() { ${GLOBAL_POLYFILL} return (${cleanedExpression}); })()`;
+    // Prepend global polyfill for Hermes compatibility
+    // Runtime.evaluate returns the completion value of the last expression naturally,
+    // so no IIFE wrapping is needed (similar to browser console behavior)
+    const wrappedExpression = `${GLOBAL_POLYFILL} ${cleanedExpression}`;
 
     return new Promise((resolve) => {
         const timeoutId = setTimeout(() => {


### PR DESCRIPTION
## Summary
- Multi-statement expressions wrapped in `(function() { ... })()` without a `return`, always returning `undefined`
- Tools that build their own IIFE (e.g. `get_component_tree`) get double-wrapped, discarding the inner return value
- `Runtime.evaluate` already returns the completion value of the last expression naturally — no IIFE needed

## Changes
- Replace IIFE wrapping with simple `GLOBAL_POLYFILL` prepend in `executeExpressionCore()`
- Remove unused `isMultiStatementExpression()` function

## Testing
- `get_component_tree` — returns full React tree (was `undefined`)
- `get_screen_layout` — returns layout data (was `undefined`)
- `find_components` — finds components (was `undefined`)
- `execute_in_app("var x = 1; x")` — returns `1` (was `undefined`)
- `list_debug_globals` — returns globals (was `undefined`)

Fixes #3