### PR TITLE
fix: remove Origin header from CDP WebSocket connection

### DIFF
--- a/src/core/connection.ts
+++ b/src/core/connection.ts
@@ -721,10 +721,9 @@ export async function connectToDevice(
         });
 
         try {
-            // Metro requires a valid Origin header matching the server's host
-            const wsUrl = new URL(device.webSocketDebuggerUrl);
-            const origin = `http://${wsUrl.hostname}:${wsUrl.port}`;
-            const ws = new WebSocket(device.webSocketDebuggerUrl, { headers: { Origin: origin } });
+            // Do not send an Origin header — Expo SDK 55+ Metro inspector proxy
+            // rejects WebSocket upgrades that include one, causing immediate close (1006)
+            const ws = new WebSocket(device.webSocketDebuggerUrl);
 
             ws.on("open", async () => {
                 // Release connection lock


### PR DESCRIPTION
## Summary

- Removes the `Origin` header from the CDP WebSocket connection in `connectToDevice()`
- Fixes Expo SDK 55 (Bridgeless C++ targets) where Metro's inspector proxy rejects connections with an `Origin` header, causing immediate close (code 1006)
- All runtime debugging features (logs, state, components, execute_in_app) were broken on these targets

## Root Cause

Expo SDK 55's Metro inspector proxy rejects WebSocket upgrade requests that include an `Origin` header. The server was adding `Origin: http://localhost:8081` to match the Metro host, but this is no longer accepted.

Verified by testing the WebSocket directly:
```js
// Immediate close (code 1006)
new WebSocket(url, { headers: { Origin: 'http://localhost:8081' } });

// Works — stays open, all CDP commands succeed
new WebSocket(url);
```

## Test plan

- [x] Verified fix on Expo SDK 55, Bridgeless [C++ connection], iPhone 17 simulator
- [x] `scan_metro` → `get_apps` shows connected device
- [x] `get_connection_status` shows CONNECTED + HEALTHY
- [x] `get_logs` captures console output
- [ ] Verify no regression on older Expo SDK / RN versions (pre-Bridgeless)

Fixes #9